### PR TITLE
add option `templates` show templates list avaliable

### DIFF
--- a/bin/sao
+++ b/bin/sao
@@ -4,8 +4,9 @@ const cac = require('cac')
 const ora = require('ora')
 const chalk = require('chalk')
 const update = require('update-notifier')
+const table = require('text-table')
 const log = require('../lib/log')
-const {getTemplates, logArray} = require('../lib/utils')
+const {getTemplates, readGlobalPackage} = require('../lib/utils')
 
 const cli = cac()
 
@@ -15,13 +16,32 @@ cli.command('*', 'Generate a new project', (input, flags) => {
   if (flags.templates) {
     const templates = getTemplates()
 
-    if (templates.length === 0) {
-      console.log(`No avaliable templates, using 'yarn global add template-name' install one now !`)
-      return
+    console.log(chalk.cyan(`\n  Templates installed from npm:\n`))
+
+    if (templates.packages.length === 0) {
+      console.log('  none')
+    } else {
+      console.log(table(templates.packages.map(item => {
+        const pkg = readGlobalPackage(item)
+        return [
+          `  ${item.replace(/-([\s\S]+)/, (m, p1) => `-${chalk.bold(p1)}`)}`,
+          chalk.dim(`v${pkg.version}`)
+        ]
+      })))
     }
 
-    console.log(`\nAvailable templates:\n`)
-    logArray(templates)
+    console.log(chalk.cyan(`\n  Templates installed from git:\n`))
+
+    if (templates.repos.length === 0) {
+      console.log('  none')
+    } else {
+      for (const item of templates.repos) {
+        console.log(`  ${item.replace(/-([\s\S]+)/, (m, p1) => `/${chalk.bold(p1)}`)}`)
+      }
+    }
+
+    console.log()
+
     return
   }
 
@@ -66,7 +86,7 @@ cli
   .option('install', 'Install relavant npm package before generating')
   .option('remove-store', 'Remove stored prompt answers')
   .option('skip-store', 'Skip stored prompt answers, i.e. do not use them')
-  .option('templates', 'Show templates global installed')
+  .option('templates', 'Show installed templates')
 
 update({pkg: cli.pkg}).notify()
 cli.parse()

--- a/bin/sao
+++ b/bin/sao
@@ -5,11 +5,26 @@ const ora = require('ora')
 const chalk = require('chalk')
 const update = require('update-notifier')
 const log = require('../lib/log')
+const {getTemplates, logArray} = require('../lib/utils')
 
 const cli = cac()
 
 cli.command('*', 'Generate a new project', (input, flags) => {
   const template = input[0]
+
+  if (flags.templates) {
+    const templates = getTemplates()
+
+    if (templates.length === 0) {
+      console.log(`No avaliable templates, using 'yarn global add template-name' install one now !`)
+      return
+    }
+
+    console.log(`\nAvailable templates:\n`)
+    logArray(templates)
+    return
+  }
+
   if (!template) {
     return cli.showHelp()
   }
@@ -51,6 +66,7 @@ cli
   .option('install', 'Install relavant npm package before generating')
   .option('remove-store', 'Remove stored prompt answers')
   .option('skip-store', 'Skip stored prompt answers, i.e. do not use them')
+  .option('templates', 'Show templates global installed')
 
 update({pkg: cli.pkg}).notify()
 cli.parse()

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,12 +7,11 @@ const home = require('user-home')
 const utils = require('./utils')
 
 const configDir = path.join(home, '.sao')
-const packagesDir = path.join(configDir, 'packages')
+const packagesDir = path.join(__dirname, '../../')
 const reposDir = path.join(configDir, 'repos')
 
 function ensureConfigDir() {
-  if (!fs.existsSync(configDir)) {
-    mkdirp.sync(packagesDir)
+  if (!fs.existsSync(reposDir)) {
     mkdirp.sync(reposDir)
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const chalk = require('chalk')
 const SAOError = require('./sao-error')
+const config = require('./config')
 
 /**
  * Check if a string is repo name
@@ -72,12 +73,13 @@ exports.escapeDots = function (str) {
 }
 
 exports.getTemplates = function () {
-  // only support templates installed by the same way with sao
-  const templatesPath = path.join(__dirname, '..', '..')
-  const templates = fs.readdirSync(templatesPath).filter(folder => /^template-/.test(folder))
-  return templates
+  const {packagesDir, reposDir} = config
+  return {
+    packages: fs.readdirSync(packagesDir).filter(folder => /^template-/.test(folder)),
+    repos: fs.readdirSync(reposDir)
+  }
 }
 
-exports.logArray = function (arr) {
-  arr.forEach(val => console.log(val))
+exports.readGlobalPackage = function (name) {
+  return require(path.join(config.packagesDir, name, 'package.json'))
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,3 +70,14 @@ exports.requireAt = function (location, name) {
 exports.escapeDots = function (str) {
   return str.replace(/\./g, '\\.')
 }
+
+exports.getTemplates = function () {
+  // only support templates installed by the same way with sao
+  const templatesPath = path.join(__dirname, '..', '..')
+  const templates = fs.readdirSync(templatesPath).filter(folder => /^template-/.test(folder))
+  return templates
+}
+
+exports.logArray = function (arr) {
+  arr.forEach(val => console.log(val))
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "parse-git-config": "^1.1.1",
     "require-from-string": "^1.2.1",
     "shelljs": "^0.7.5",
+    "text-table": "^0.2.0",
     "tildify": "^1.2.0",
     "update-notifier": "^1.0.3",
     "user-home": "^2.0.0",


### PR DESCRIPTION
now can use `sao --templates` get avaliable templates list

cause #20 ,only support templates installed by the same way with sao

maybe can recommend people add `sao-templates` in templates  key words